### PR TITLE
Fix bug in pseudo-classes markdown.

### DIFF
--- a/src/site/content/en/learn/css/pseudo-classes/index.md
+++ b/src/site/content/en/learn/css/pseudo-classes/index.md
@@ -98,7 +98,7 @@ button:focus {
 This CSS removes the default browser focus ring when an element receives focus,
 which presents an accessibility issue for users who navigate a web page with a keyboard.
 If there is no focus style,
-they won't be able to keep track of where focus currently is when the <kbd>tab<kbd>.
+they won't be able to keep track of where focus currently is when the <kbd>tab</kbd>.
 With [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible)
 you can present a focus style when an element receives focus via the keyboard,
 while also using the `outline: none` rule to prevent it when a pointer device interacts with it.


### PR DESCRIPTION
Instead of nested <kbd> elements, close the <kbd> element. The nested elements were breaking the layout. 

Fixes https://github.com/GoogleChrome/web.dev/issues/5430.

<!-- Googlers: Please complete go/web.dev-content-proposal before
     submitting PRs that create new pages of content. -->

<!-- If you're PR isn't ready for review yet, please set it to draft mode:
     https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
